### PR TITLE
add an additionnal folder verification before uploading a file

### DIFF
--- a/lib/transfers/ftp.js
+++ b/lib/transfers/ftp.js
@@ -87,25 +87,31 @@ module.exports = class FtpTransfer extends Transfer {
 
             // normalize for unix
             targetFile = targetFile.split(path.sep).join("/");
+            var targetDir = targetFile.replace(/\/[^\/]+$/,'');
             var tmpFilename = targetFile + "_tmp_" + Date.now();
 
             return this.connect().then(() => {
-                this.conn.put(file, tmpFilename, (err) => {
+                this.conn.mkdir(targetDir,true, (err) => {
                     if (err) {
                         return reject(new Error(err));
                     }
-
-                    this.conn.rename(tmpFilename, targetFile, (err) => {
+                    this.conn.put(file, tmpFilename, (err) => {
                         if (err) {
-                            return this.conn.delete(tmpFilename, (err2) => {
-                                return reject(new Error(err));
-                            });
+                            return reject(new Error(err));
                         }
 
-                        if (!leaveConnectionOpen) {
-                            this.disconnect();
-                        }
-                        return resolve();
+                        this.conn.rename(tmpFilename, targetFile, (err) => {
+                            if (err) {
+                                return this.conn.delete(tmpFilename, (err2) => {
+                                    return reject(new Error(err));
+                                });
+                            }
+
+                            if (!leaveConnectionOpen) {
+                                this.disconnect();
+                            }
+                            return resolve();
+                        });
                     });
                 });
 


### PR DESCRIPTION
When uploading a file within a non previously existing folder the script just return an error and crash.
Now the missing folder tree will be created then the file is uploaded